### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.FileStorage.nuspec
+++ b/MakoIoT.Device.Services.FileStorage.nuspec
@@ -24,8 +24,8 @@
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.23" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
       <dependency id="nanoFramework.System.Text" version="1.2.37" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.0.35" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.37.9044" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
+++ b/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
@@ -25,15 +25,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.37.9044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.FileStorage/packages.config
+++ b/src/MakoIoT.Device.Services.FileStorage/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.37.9044" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.37.9044</br>Bumps nanoFramework.DependencyInjection from 1.0.35 to 1.1.1</br>
[version update]

### :warning: This is an automated update. :warning:
