### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
@@ -54,12 +54,12 @@
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.93.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.93\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.93\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
@@ -8,5 +8,5 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.56" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.6" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.93" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.94" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 2.1.93 to 2.1.94</br>
[version update]

### :warning: This is an automated update. :warning:
