### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Runtime, Version=1.0.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.6\lib\nanoFramework.System.Runtime.dll</HintPath>
+    <Reference Include="nanoFramework.System.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.27\lib\nanoFramework.System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
@@ -6,7 +6,7 @@
   <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.45" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Runtime" version="1.0.6" />
+  <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.94" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
+++ b/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
@@ -44,8 +44,8 @@
       <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Runtime, Version=1.0.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.6\lib\nanoFramework.System.Runtime.dll</HintPath>
+    <Reference Include="nanoFramework.System.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.27\lib\nanoFramework.System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.FileStorage/packages.config
+++ b/src/MakoIoT.Device.Services.FileStorage/packages.config
@@ -7,7 +7,7 @@
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.45" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Runtime" version="1.0.6" />
+  <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.System.Runtime from 1.0.6 to 1.0.27</br>
[version update]

### :warning: This is an automated update. :warning:
