### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
@@ -49,11 +49,11 @@
     <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.113.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.113\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.42\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.113\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.42\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.54\lib\System.IO.FileSystem.dll</HintPath>

--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
@@ -8,5 +8,5 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.113" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.42" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 2.1.113 to 3.0.42</br>
[version update]

### :warning: This is an automated update. :warning:
