### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.FileStorage.nuspec
+++ b/MakoIoT.Device.Services.FileStorage.nuspec
@@ -24,7 +24,7 @@
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
       <dependency id="nanoFramework.System.Text" version="1.3.36" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
     </dependencies>
   </metadata>
   <files>

--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/MakoIoT.Device.Services.FileStorage.DeviceTest.nfproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.53.21413\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>

--- a/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
+++ b/TestsHardware/MakoIoT.Device.Services.FileStorage.DeviceTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />

--- a/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
+++ b/src/MakoIoT.Device.Services.FileStorage/MakoIoT.Device.Services.FileStorage.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.53.21413\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.FileStorage/packages.config
+++ b/src/MakoIoT.Device.Services.FileStorage/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.53.21413 to 1.0.54.39044</br>
[version update]

### :warning: This is an automated update. :warning:
